### PR TITLE
fix UltraEconomyAPI depend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		</repository>
 		<repository>
 			<id>techscode</id>
-			<url>https://repo.techscode.com/repository/maven-releases/</url>
+			<url>https://repo.techscode.com/repository/techscode-apis/</url>
 		</repository>
 		<repository>
 			<id>placeholderapi</id>
@@ -193,7 +193,7 @@
 		<dependency>
 			<groupId>me.TechsCode</groupId>
 			<artifactId>UltraEconomyAPI</artifactId>
-			<version>2.6.4</version>
+			<version>1.1.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
UltraEconomyAPI moved their repo to https://repo.techscode.com/repository/techscode-apis/ and changed the version number